### PR TITLE
Enable Highcharts exporting

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "cookie-parser": "1.4.1",
     "express": "4.13.4",
     "fb-sleep": "2.2.0",
+    "highcharts-exporting": "^0.1.2",
+    "highcharts-offline-exporting": "^0.1.2",
     "lodash": "4.5.1",
     "lowdb": "0.12.4",
     "moment": "2.11.2",

--- a/public/index.html
+++ b/public/index.html
@@ -7,5 +7,7 @@
   <body>
     <div id="sleep-stats-app"></div>
     <script src="/public/bundle.js"></script>
+    <script src="http://code.highcharts.com/modules/exporting.js"></script>
+    <script src="http://code.highcharts.com/modules/offline-exporting.js"></script>
   </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,5 @@
   <body>
     <div id="sleep-stats-app"></div>
     <script src="/public/bundle.js"></script>
-    <script src="http://code.highcharts.com/modules/exporting.js"></script>
-    <script src="http://code.highcharts.com/modules/offline-exporting.js"></script>
   </body>
 </html>

--- a/src/browser/components/User.jsx
+++ b/src/browser/components/User.jsx
@@ -1,4 +1,6 @@
 var React = require('react');
+require('highcharts-exporting');
+require('highcharts-offline-exporting');
 var Highcharts = require('react-highcharts/bundle/highcharts');
 var userService = require('../services/user');
 var chartService = require('../services/chart');

--- a/src/browser/components/User.jsx
+++ b/src/browser/components/User.jsx
@@ -1,7 +1,7 @@
 var React = require('react');
-require('highcharts-exporting');
-require('highcharts-offline-exporting');
 var Highcharts = require('react-highcharts/bundle/highcharts');
+require('highcharts-exporting')(Highcharts.Highcharts);
+require('highcharts-offline-exporting')(Highcharts.Highcharts);
 var userService = require('../services/user');
 var chartService = require('../services/chart');
 var moment = require('moment');

--- a/src/browser/services/chart.js
+++ b/src/browser/services/chart.js
@@ -139,6 +139,9 @@ chartService.getConfig = function(timestamps) {
     });
 
     return {
+        exporting: {
+            sourceWidth: 1200
+        },
         plotOptions: {
             series: {
                 animation: false,


### PR DESCRIPTION
Hi there!
I needed to enable **Highcharts**' [client side export](http://www.highcharts.com/docs/export-module/client-side-export).  
I'm [not used to](https://i.imgur.com/zU94ioE.png) **React** though, so I don't really know why [requiring modules](https://github.com/libe-sixplus/fb-sleep-stats/blob/ce411e6b61b29d10639a05a18ec4465946419348/src/browser/components/User.jsx#L2-L3) in `User.jsx` is not working. I was lacking some time to :mag: investigate this so I [linked](https://github.com/libe-sixplus/fb-sleep-stats/blob/ce411e6b61b29d10639a05a18ec4465946419348/public/index.html#L10-L11) **Highcharts**' scripts directly in the `index.html`.
It feels pretty ugly so feel free to change this.
